### PR TITLE
Handle the case where the lexer cannot produce any tokens

### DIFF
--- a/src/zc_parser.rs
+++ b/src/zc_parser.rs
@@ -1061,7 +1061,6 @@ impl<AT:Default,ET:Default> ZCParser<AT,ET>
     let mut lookahead = TerminalToken::new("EOF",AT::default(),0,0); //just init
     // nextsym() should only be called here
     if let Some(tok) = tokenizer.nextsym() {lookahead=tok;}
-    else {self.stopparsing=true;}
 
     while !self.stopparsing
     {


### PR DESCRIPTION
If, upon requesting the first token from the lexer via `nextsym()` the result is `None`, parsing will immediately stop and the result returned. However, that means that grammars with nullable start symbols such as

```
nonterminals Program
topsym Program

Program --> { ... }

EOF
```

will not be handled correctly.

I have not fully familiarized myself with the codebase, but as far as I can tell it is safe to delete the `else` branch entirely because `lookahead` was previously set to `"EOF"`. Testing it on the default `StrTokenizer` lexer with an empty input and the above empty grammar executes the semantic actions for `Program` so it seems to work as intended.