### PR TITLE
Add top-level expect declaration à la Bison

### DIFF
--- a/src/grammar_processor.rs
+++ b/src/grammar_processor.rs
@@ -150,6 +150,7 @@ pub struct Grammar
   pub startrulei: usize,
   pub mode: i32, // generic mode information
   pub bumpast: bool,
+  pub expect: usize,
 }
 
 impl Default for Grammar {
@@ -201,6 +202,7 @@ impl Grammar
        startrulei : 0,
        mode : 0,
        bumpast: false,
+       expect : 0,
      }
   }//new grammar
 
@@ -701,6 +703,15 @@ impl Grammar
               */
               eprintln!("WARNING: DECLARATION IGNORED, Line {}. The transform directive was only used in Rustlr version 0.2.96 and no longer supported.  Use the shared_state variable for a more general solution.",linenum);
             },
+
+             "expect" if stage<2 => {
+                 if let Ok(num) = stokens[1].parse::<usize>() {
+                    self.expect = num;
+                 } else {
+                     eprintln!("MALFORMED expect declaration skipped, line {}",linenum);
+                     continue;
+                 }
+             },
 //////////// case for grammar production:
 
 	    LHS0 if stokens.len()>1 => {

--- a/src/lr_statemachine.rs
+++ b/src/lr_statemachine.rs
@@ -608,8 +608,10 @@ pub fn sr_resolve(Gmr:&Grammar, ri:&usize, la:usize, si:usize,conflicts:&mut Has
      else {
        clearly_resolved=false;
        // report unclear case
-       println!("Shift-Reduce conflict between lookahead {} and rule {} in state {} not clearly resolved, defaulting to Shift",&Gmr.Symbols[la].sym,ri,si);
-       printrulela(*ri,Gmr,la);
+         if conflicts.len() >= Gmr.expect {
+             println!("Shift-Reduce conflict between lookahead {} and rule {} in state {} not clearly resolved, defaulting to Shift", &Gmr.Symbols[la].sym, ri, si);
+             printrulela(*ri, Gmr, la);
+         }
      }
      conflicts.insert((*ri,la),(clearly_resolved,resolution));
      resolution

--- a/src/lr_statemachine.rs
+++ b/src/lr_statemachine.rs
@@ -601,8 +601,10 @@ pub fn sr_resolve(Gmr:&Grammar, ri:&usize, la:usize, si:usize,conflicts:&mut Has
        resolution = true;
        if lapred==0 {
           clearly_resolved = false;
-          println!("Shift-Reduce conflict between lookahead {} and rule {} in state {} not clearly resolved, defaulting to Reduce because the rule has positive precedence.",&Gmr.Symbols[la].sym,ri,si);
-          printrulela(*ri,Gmr,la);
+           if conflicts.len() >= Gmr.expect {
+               println!("Shift-Reduce conflict between lookahead {} and rule {} in state {} not clearly resolved, defaulting to Reduce because the rule has positive precedence.",&Gmr.Symbols[la].sym,ri,si);
+               printrulela(*ri,Gmr,la);
+           }
        }
      } // reduce
      else {


### PR DESCRIPTION
This pull request represents a draft for adding Bison-style `%expect` declarations to Rustlr, which look like

```
expect n
```

and cause Rustlr to suppress warnings for the first `n` shift/reduce conflicts it encounters. Obviously, this feature is most useful when you can also attach `expect` declarations to individual grammar rules which allows you to explicitly acknowledge harmless shift/reduce conflicts and cut down on the noise in the diagnostic messages. However, it's not totally obvious how to integrate that into Rustlr's syntax, and furthermore a bit more involved to implement so I wanted to check if there is interest in introducing this feature first. 

Thoughts? I personally find this a very nice feature of Bison.

EDIT: This probably would have been better as an issue/feature request. To be clear, this PR is not intended to be merged as-is.