### PR TITLE
Fix multi-byte Unicode comment tokens

### DIFF
--- a/examples/commentcalc/Cargo.toml
+++ b/examples/commentcalc/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "commentcalc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rustlr = { path = "../../../rustlr", default-features = false }

--- a/examples/commentcalc/commentcalc.grammar
+++ b/examples/commentcalc/commentcalc.grammar
@@ -1,0 +1,33 @@
+auto
+terminals + * - / ; ( )
+valterminal Int i32
+nonterminal E
+nonterminal T : E
+nonterminal F : E
+nonterminal ExpList
+startsymbol ExpList
+variant-group-for E BinaryOp + - * /
+lexattribute set_line_comment(r"⍝")
+
+E --> E + T | E - T | T
+T --> T * F | T / F | F
+F:Neg --> - F
+F --> Int | ( E )
+ExpList --> E<;+> ;?
+
+!mod commentcalc_ast;
+!fn main()  {
+!  let mut scanner1 = commentcalclexer::from_str(r"
+!10+-2*4;
+!⍝ example comment
+!9-(4-1)");
+!  let mut parser1 = make_parser(scanner1);
+!  let parseresult = parse_with(&mut parser1);
+!  let ast =
+!    parseresult.
+!    unwrap_or_else(|x| {
+!       println!("Parsing errors encountered; results not guaranteed..");
+!       x
+!    });
+!  println!("\nAST: {:?}\n",&ast);
+!}

--- a/src/lexer_interface.rs
+++ b/src/lexer_interface.rs
@@ -832,7 +832,7 @@ impl<'t> StrTokenizer<'t>
     }//for each custom key
 
     // look for line comment
-    if clen>0 && pi+clen<=self.input.len() && self.line_comment==&self.input[pi..pi+clen] {
+    if clen>0 && pi+clen<=self.input.len() && self.input.is_char_boundary(pi+clen) && self.line_comment==&self.input[pi..pi+clen] {
       if let Some(nlpos) = self.input[pi+clen..].find("\n") {
         self.position = nlpos+pi+clen;
         if self.keep_comment {


### PR DESCRIPTION
Hi! Love the project, probably the best parser library I have worked with so far, has helped me quite a lot!

However I have found a small bug relating to multi-byte Unicode comments tokens: The example demonstrates a minimal example of the issue and I have implemented a very simple fix for the issue.

Thanks for the great work! I plan on sticking with this library since it very elegantly solves many of the problems I've experienced with other libraries, the automatic conflict resolution in particular is extremely helpful!

Aistis Raulinaitis